### PR TITLE
フォロー機能(非同期)の追加

### DIFF
--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/shoes.scss
+++ b/app/assets/stylesheets/shoes.scss
@@ -1067,3 +1067,15 @@ footer p {
 .search-form .search-btn {
   width: 10%;
 }
+
+#follow, #follower {
+  color: #fff;
+  background-color: #999;
+  border-radius: 14px;
+  margin-bottom: 2px;
+  text-align: center;
+}
+
+.user_name {
+  font-size: 20px;
+}

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,15 @@
+class RelationshipsController < ApplicationController
+
+  def create
+    @user = User.find(params[:following_id])
+    current_user.follow(@user)
+    
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    current_user.unfollow(@user)
+    
+  end
+  
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,21 @@
 class UsersController < ApplicationController
 
   def show
-    user = User.find(params[:id])
-    @name = current_user.name
-    @shoes = current_user.shoes
+    @user = User.find(params[:id])
+    @name = @user.name
+    @shoes = @user.shoes.order("created_at DESC")
+  end
+
+  def following
+    #@userがフォローしているユーザー
+    @user  = User.find(params[:id])
+    @users = @user.following
+  end
+
+  def followers
+    #@userをフォローしているユーザー
+    @user  = User.find(params[:id])
+    @users = @user.followers
   end
 
 end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,9 @@
+class Relationship < ApplicationRecord
+  #自分をフォローしているユーザー
+  belongs_to :follower, class_name: "User"
+  #自分がフォローしているユーザー
+  belongs_to :following, class_name: "User"
+  #バリデーション
+  validates :follower_id, presence: true
+  validates :following_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,32 @@ class User < ApplicationRecord
 
   has_many :shoes
   has_many :comments
-
+  
   has_many :favorites, dependent: :destroy
+  has_many :following_relationships, foreign_key: "follower_id", class_name: "Relationship",  dependent: :destroy
+  has_many :following, through: :following_relationships
+  has_many :follower_relationships, foreign_key: "following_id", class_name: "Relationship", dependent: :destroy
+  has_many :followers, through: :follower_relationships
 
   # いいねを判断するメソッド
   def already_favorited?(shoe)
     self.favorites.exists?(shoe_id: shoe.id)
   end
+
+  
+  #フォローしているかを確認するメソッド
+  def following?(user)
+    self.following_relationships.find_by(following_id: user.id)
+  end
+
+  #フォローするときのメソッド
+  def follow(user)
+    self.following_relationships.create(following_id: user.id)
+  end
+
+  #フォローを外すときのメソッド
+  def unfollow(user)
+    self.following_relationships.find_by(following_id: user.id).destroy
+  end
+
 end

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,1 @@
+$("#follow_form").html("<%= j(render partial: 'users/unfollow', locals: { user: @user }) %>");

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#follow_form").html("<%= j(render partial: 'users/follow', locals: { user: @user }) %>");

--- a/app/views/users/_follow.html.haml
+++ b/app/views/users/_follow.html.haml
@@ -1,0 +1,12 @@
+<!-- フォローボタン ------------------------------------------------------------------>
+#follower
+  フォロワー
+  = @user.followers.count
+  人
+#follow
+  フォロー
+  = @user.following.count
+  人
+= form_for(current_user, url: relationships_path, method: :post, remote: true) do |form|
+  = hidden_field_tag :following_id, user.id
+  = form.submit "フォローする"

--- a/app/views/users/_follow_form.html.haml
+++ b/app/views/users/_follow_form.html.haml
@@ -1,0 +1,16 @@
+<!-- フォローボタンMYPAGEのユーザーがcurrent_userでなければ表示------------------------------------------------------>
+- if user_signed_in? && user != current_user
+  #follow_form
+    - if current_user.following?(user)
+      = render partial: "unfollow", locals: { user: user }
+    - else
+      = render partial: "follow", locals: { user: user }
+- else
+  #follower
+    フォロワー
+    = @user.followers.count
+    人
+  #follow
+    フォロー
+    = @user.following.count
+    人

--- a/app/views/users/_unfollow.html.haml
+++ b/app/views/users/_unfollow.html.haml
@@ -1,0 +1,10 @@
+#follower
+  フォロワー
+  = @user.followers.count
+  人
+#follow
+  フォロー
+  = @user.following.count
+  人
+= form_for(current_user, url: relationship_path(user), method: :delete, remote: true) do |form|
+  = form.submit "フォロー解除"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,7 +1,8 @@
 .contents.row
-  %p
+  %p.user_name
     = @name
-    さんの投稿一覧
+    の投稿一覧
+    = render partial: "follow_form", locals: { user: @user }
   - @shoes.each do |shoe|
     = render partial: "shoes/shoe", locals: { shoe: shoe }
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,10 @@ Rails.application.routes.draw do
       get 'search'
     end
   end
-  resources :users, only: :show
+  resources :users do
+    member do
+      get :following, :followers
+    end
+  end
+  resources :relationships, only: [:create, :destroy]
 end

--- a/db/migrate/20200621122147_create_relationships.rb
+++ b/db/migrate/20200621122147_create_relationships.rb
@@ -1,0 +1,12 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :following_id
+
+      t.index [:follower_id, :following_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_034750) do
+ActiveRecord::Schema.define(version: 2020_06_21_122147) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -25,6 +25,14 @@ ActiveRecord::Schema.define(version: 2020_06_18_034750) do
     t.integer "shoe_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "following_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["follower_id", "following_id"], name: "index_relationships_on_follower_id_and_following_id", unique: true
   end
 
   create_table "shoes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  following_id: 1
+
+two:
+  follower_id: 1
+  following_id: 1

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#What
フォロー機能の追加、ユーザーページでのフォロー数、フォロワー数を表示を非同期で処理ができる。

#Why
フォロー数、フォロワー数を確認するため。
また非同期にすることによりスムーズにストレスなく表示できるため。
